### PR TITLE
chore: replace head -1 with p6_filter_row_first in lib/cli/vnet.sh

### DIFF
--- a/lib/cli/vnet.sh
+++ b/lib/cli/vnet.sh
@@ -22,7 +22,7 @@ p6df::modules::cloudflare::warp::vnet::list() {
 ######################################################################
 p6df::modules::cloudflare::warp::vnet::current() {
 
-  p6df::modules::cloudflare::warp::cli "warp-cli vnet | head -1"
+  p6df::modules::cloudflare::warp::cli "warp-cli vnet | p6_filter_row_first 1"
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Replace `| head -1` with `| p6_filter_row_first 1` in `lib/cli/vnet.sh:25`

## Test plan

- [ ] `p6df::modules::cloudflare::warp::vnet::current` returns first vnet line correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)