### PR TITLE
fix(cloudflare): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -56,5 +56,5 @@ p6df::modules::cloudflare::mcp() {
 ######################################################################
 p6df::modules::cloudflare::profile::mod() {
 
-  p6_return_words 'cloudflare' "$CLOUDFLARE_API_TOKEN"
+  p6_return_words 'cloudflare' '$CLOUDFLARE_API_TOKEN'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None