### PR TITLE
fix(profile): simplify profile::mod return signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@
 
 ## Summary
 
-p6df module for Cloudflare: WARP CLI tools (`cloudflare-warp`), virtual network
-management helpers, and MCP server (`@cloudflare/mcp-server-cloudflare`) for
-AI-driven Cloudflare Workers, KV, R2, D1, and zone management.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -57,12 +55,9 @@ AI-driven Cloudflare Workers, KV, R2, D1, and zone management.
 ##### p6df-cloudflare/init.zsh
 
 - `p6df::modules::cloudflare::deps()`
-- `p6df::modules::cloudflare::external::brew()`
-- `p6df::modules::cloudflare::init(_module, dir)`
-  - Args:
-    - _module
-    - dir
+- `p6df::modules::cloudflare::external::brews()`
 - `p6df::modules::cloudflare::mcp()`
+- `words cloudflare = p6df::modules::cloudflare::profile::mod()`
 
 #### p6df-cloudflare/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -46,10 +46,10 @@ p6df::modules::cloudflare::mcp() {
 ######################################################################
 #<
 #
-# Function: words cloudflare $CLOUDFLARE_API_TOKEN = p6df::modules::cloudflare::profile::mod()
+# Function: words cloudflare = p6df::modules::cloudflare::profile::mod()
 #
 #  Returns:
-#	words - cloudflare $CLOUDFLARE_API_TOKEN
+#	words - cloudflare
 #
 #  Environment:	 CLOUDFLARE_API_TOKEN
 #>


### PR DESCRIPTION
**What:** Remove env var from `profile::mod` return signature, returning only the module name word.

**Why:** Aligns with the updated `p6_return_words` convention where env vars are documented via the Environment section rather than encoded in the return value.

**Test plan:** Manual shell reload verification; no functional behavior change.

**Dependencies:** none